### PR TITLE
Interface ctrl small add

### DIFF
--- a/MyPenelopF/src/main/java/App.java
+++ b/MyPenelopF/src/main/java/App.java
@@ -1,21 +1,37 @@
 import java.io.IOException;
+import java.util.ArrayList;
 
 import controllers.ContactController;
 import controllers.GroupController;
+import controllers.PenelopeController;
 
 /*
  * MyPenelopeF entry point
  */
 public class App
 {
+	// L'app stocke un array de PenelopeController
+	// ce type correspond à une interface.
+	// pour implémenter cette interface et être un
+	// putin de PeneloppeController, il faut
+	// avoir la méthode init appellée ici dans le for
+	static ArrayList<PenelopeController> ctrls;
+	
     public static void main( String[] args ) throws IOException
     {
-    	// delete once FileSystem is legit and safe
-    	// App.setDummyData();
-    	// Controllers are the only actors in main
-    	final ContactController cCtrl = new ContactController();
-    	cCtrl.initContact();
-    	final GroupController gCtrl = new GroupController();
-    	gCtrl.initGroup();
+    	App.init();
+    	for (PenelopeController ctrl: App.ctrls)
+    		ctrl.init();
+    }
+    
+    // Ca permet de simplifier le 'enable/disable' d'un controller
+    // en gérant son ajout et son init juste en ajoutant une ligne ici
+    // encore faut-il que les classes Controllers implémentent
+    // la méthode init().
+    private static final void init() {
+    	App.ctrls  = new ArrayList<PenelopeController>();
+    	App.ctrls.add(new ContactController());
+    	App.ctrls.add(new GroupController());
+    	// App.ctrls.add(new xxxController());
     }
 }

--- a/MyPenelopF/src/main/java/controllers/ContactController.java
+++ b/MyPenelopF/src/main/java/controllers/ContactController.java
@@ -20,14 +20,14 @@ import utils.PenelopDevLogger;
  * implement observer pattern (interface CreateContactListener work with ihm.contact.CreateContact)
  * Calls on singletons.
  */
-public class ContactController implements ContactListener {
+public class ContactController implements PenelopeController, ContactListener {
 	// Singletons calls on utilitarie classes
 	public BaseFrame base;
 	public BaseFrame uForm;
 	final static PenelopDevLogger log = PenelopDevLogger.get();
 	final static ContactDAO contactDAO = (ContactDAO) DAOFactory.getContactDAO(FileSystemManager.get());
 	
-	public void initContact() {
+	public void init() {
 		contactDAO.createDummyContacts();
         ArrayList<Contact> retrievedContacts = contactDAO.get();
         System.out.println("INIT CONTACT");

--- a/MyPenelopF/src/main/java/controllers/ContactController.java
+++ b/MyPenelopF/src/main/java/controllers/ContactController.java
@@ -1,6 +1,5 @@
 package controllers;
 
-import java.io.IOException;
 import java.util.ArrayList;
 
 import DAO.DAOFactory;
@@ -17,46 +16,53 @@ import utils.PenelopDevLogger;
  * ContactController
  * Initialize view using ihm package,
  * manage logic and FileSystem update using ContactUtils classe
- * implement observer pattern (interface CreateContactListener work with ihm.contact.CreateContact)
+ * implement observer pattern 
+ * (interface CreateContactListener work with ihm.contact.CreateContact)
  * Calls on singletons.
  */
 public class ContactController implements PenelopeController, ContactListener {
 	// Singletons calls on utilitarie classes
+	final static PenelopDevLogger log = PenelopDevLogger.get();
+	final static ContactDAO contactDAO = (ContactDAO) DAOFactory
+			.getContactDAO(FileSystemManager.get());
+	// View elements
 	public BaseFrame base;
 	public BaseFrame uForm;
-	final static PenelopDevLogger log = PenelopDevLogger.get();
-	final static ContactDAO contactDAO = (ContactDAO) DAOFactory.getContactDAO(FileSystemManager.get());
 	
 	public void init() {
 		contactDAO.createDummyContacts();
         ArrayList<Contact> retrievedContacts = contactDAO.get();
-        System.out.println("INIT CONTACT");
+        log._("INIT CONTACT");
         log.contacts(retrievedContacts);
         this.base = new BaseFrame(this, retrievedContacts);
         contactDAO.addContactListener(this);
 	}
 	
+	/**
+	 *  Observer pattern => ContactListener
+	 *  Interact with ihm.contact and ContactDAO
+	 *  ModelView linked by Observer pattern in controller
+	 */
 	public void CreateContactTriggered(Contact nContact) {
-		System.out.println("Triggered contact");
-    	System.out.println("CREATE CONTACT");
+    	log._("CREATE CONTACT");
 		log.contact(nContact);
 		contactDAO.add(nContact);
 	}
 	
 	public void DeleteContactTriggered(Contact dContact) {
-    	System.out.println("DELETE CONTACT");
+    	log._("DELETE CONTACT");
 		log.contact(dContact);
 		contactDAO.remove(dContact);
 	}
 
 	public void ShowUpdateTriggered(Contact c) {
-    	System.out.println("SHOW UPDATE CONTACT WITH:");
+    	log._("SHOW UPDATE CONTACT WITH:");
 		log.contact(c);
 		this.uForm = new BaseFrame(this, c);
 	}
 	
 	public void UpdateContactTriggered(Contact uContact) {
-    	System.out.println("CREATE CONTACT");
+    	log._("CREATE CONTACT");
 		log.contact(uContact);
 		contactDAO.update(uContact);
 	}
@@ -65,9 +71,10 @@ public class ContactController implements PenelopeController, ContactListener {
 		this.refreshContact();
 	}
 	
+	//
 	private void refreshContact() {
         ArrayList<Contact> retrievedContacts = contactDAO.get();
-        System.out.println("REFRESH CONTACT");
+        log._("REFRESH CONTACT");
         log.contacts(retrievedContacts);
         this.base.refreshContactPanel(retrievedContacts);
 	}

--- a/MyPenelopF/src/main/java/controllers/GroupController.java
+++ b/MyPenelopF/src/main/java/controllers/GroupController.java
@@ -11,13 +11,13 @@ import utils.GroupListener;
 import utils.GroupUtils;
 import utils.PenelopDevLogger;
 
-public class GroupController implements GroupListener, CreateGroupListener {
+public class GroupController implements PenelopeController, GroupListener, CreateGroupListener {
 
 	public BaseFrame base;
 	final static PenelopDevLogger log = PenelopDevLogger.get();
 	final static GroupUtils gUtils = GroupUtils.get();
 	
-	public void initGroup() {
+	public void init() {
         try {
         	ArrayList<Group> retrievedGroups = gUtils.getGroups();
         	System.out.println("INIT GROUP");

--- a/MyPenelopF/src/main/java/controllers/GroupController.java
+++ b/MyPenelopF/src/main/java/controllers/GroupController.java
@@ -3,7 +3,6 @@ package controllers;
 import java.io.IOException;
 import java.util.ArrayList;
 
-import classes.Contact;
 import classes.Group;
 import ihm.BaseFrame;
 import ihm.group.CreateGroupListener;

--- a/MyPenelopF/src/main/java/controllers/PenelopeController.java
+++ b/MyPenelopF/src/main/java/controllers/PenelopeController.java
@@ -1,0 +1,5 @@
+package controllers;
+
+public interface PenelopeController {
+	public void init();
+}

--- a/MyPenelopF/src/main/java/utils/PenelopDevLogger.java
+++ b/MyPenelopF/src/main/java/utils/PenelopDevLogger.java
@@ -16,6 +16,10 @@ public class PenelopDevLogger {
 		return SingletonHolder.instance;
 	}
 	
+	public void _(String str) {
+    	System.out.println(str);
+	}
+	
 	public void contacts(ArrayList<Contact> contacts) {
 		for (Contact c: contacts) {
         	System.out.println("User n°" + c.getId());


### PR DESCRIPTION
Même principe que pour DataInterface.
On substitue nos type ContactController et GroupController à un type interface PenelopeController.
Le main s'en fou de savoir si il init un ContactController ou un GroupController, lui il init des controllers....
Pareil pour DataInterface: les DAOs s'en foutent de savoir si un .writeContacts() va faire une requête SQL ou un file.Write, le DAO il veut persister des contacts. Donc créant DataInterface, on peut remplacer FileSytemManager par un autre gestionnaire d'accès aux data. Sans toucher les DAOs, sans toucher les controllers et évidemment sans toucher les vues...  par contre, comme dans cette PR, il faudra que notre DataInterface implémente les méthodes requises.